### PR TITLE
chore(dev): add direnv devenv setup

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,5 +1,6 @@
 [[pre-start]]
 copy = "wt step copy-ignored --force"
+direnv = "direnv allow ."
 install = "portless-worktree-dev install"
 
 [post-start]

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .cache/
+.direnv/
 .devenv/
 .next/
 out/

--- a/README.md
+++ b/README.md
@@ -13,8 +13,15 @@ Personal portfolio for [adrianmross.github.io](https://adrianmross.github.io), r
 ## Local Development
 
 ```sh
+direnv allow
 pnpm install
 pnpm run dev
+```
+
+Without direnv, enter the same pinned toolchain manually:
+
+```sh
+devenv shell
 ```
 
 Build the GitHub Pages artifact:


### PR DESCRIPTION
## Summary
- add a committed .envrc that loads the existing devenv shell through direnv
- allow direnv automatically in WorkTrunk pre-start hooks
- document direnv and devenv local development entry points

## Validation
- direnv allow .
- direnv export bash
- devenv test
- devenv shell -- pnpm run typecheck