### PR TITLE
fix(security): encode blog post slugs

### DIFF
--- a/app/components/posts.tsx
+++ b/app/components/posts.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { getPosts, type Post } from '@/lib/posts'
+import { getBlogPostPath, getPosts, type Post } from '@/lib/posts'
 import { cn } from '@/lib/utils'
 
 const fullDateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -56,7 +56,7 @@ export function BlogPosts({ includeDrafts = false, showDraftStatus = false }: Bl
             'flex flex-col space-y-1 mb-4',
             post.draft && 'opacity-45 hover:opacity-70',
           )}
-          href={`/blog/${post.slug}`}
+          href={getBlogPostPath(post.slug)}
         >
           <BlogPostContent post={post} showDraftStatus={showDraftStatus} />
         </Link>

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,29 +1,50 @@
 import { site } from '@/site'
-import { getPosts } from '@/lib/posts'
+import { getBlogPostUrl, getPosts } from '@/lib/posts'
 
 export const dynamic = 'force-static'
+
+function escapeXml(value: string) {
+  return value.replace(/[<>&'"]/g, (character) => {
+    switch (character) {
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '&':
+        return '&amp;'
+      case "'":
+        return '&apos;'
+      case '"':
+        return '&quot;'
+      default:
+        return character
+    }
+  })
+}
 
 export function GET() {
   const posts = getPosts()
   const items = posts
-    .map(
-      (post) => `
+    .map((post) => {
+      const postUrl = getBlogPostUrl(post.slug, site.url)
+
+      return `
         <item>
-          <title>${post.title}</title>
-          <link>${site.url}/blog/${post.slug}</link>
-          <guid>${site.url}/blog/${post.slug}</guid>
+          <title>${escapeXml(post.title)}</title>
+          <link>${escapeXml(postUrl)}</link>
+          <guid>${escapeXml(postUrl)}</guid>
           <pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>
-          <description>${post.summary}</description>
-        </item>`,
-    )
+          <description>${escapeXml(post.summary)}</description>
+        </item>`
+    })
     .join('')
 
   const xml = `<?xml version="1.0" encoding="UTF-8" ?>
     <rss version="2.0">
       <channel>
-        <title>${site.name}</title>
-        <link>${site.url}</link>
-        <description>${site.description}</description>
+        <title>${escapeXml(site.name)}</title>
+        <link>${escapeXml(site.url)}</link>
+        <description>${escapeXml(site.description)}</description>
         ${items}
       </channel>
     </rss>`

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 import { site } from '@/site'
-import { getPosts } from '@/lib/posts'
+import { getBlogPostUrl, getPosts } from '@/lib/posts'
 
 export const dynamic = 'force-static'
 
@@ -11,7 +11,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   }))
 
   const posts = getPosts().map((post) => ({
-    url: `${site.url}/blog/${post.slug}`,
+    url: getBlogPostUrl(post.slug, site.url),
     lastModified: new Date(post.publishedAt),
   }))
 

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import matter from 'gray-matter'
 
 const postsDirectory = path.join(process.cwd(), 'content/posts')
+const postSlugPattern = /^[a-z0-9-]+$/
 const postFilenamePattern = /^[a-z0-9-]+\.mdx$/
 
 export type Post = {
@@ -48,4 +49,16 @@ export function getPosts({ includeDrafts = false }: GetPostsOptions = {}): Post[
 
 export function getPost(slug: string, options?: GetPostsOptions) {
   return getPosts(options).find((post) => post.slug === slug)
+}
+
+export function getBlogPostPath(slug: string) {
+  if (!postSlugPattern.test(slug)) {
+    throw new Error(`Invalid blog post slug: ${slug}`)
+  }
+
+  return `/blog/${encodeURIComponent(slug)}`
+}
+
+export function getBlogPostUrl(slug: string, baseUrl: string) {
+  return new URL(getBlogPostPath(slug), baseUrl).toString()
 }


### PR DESCRIPTION
## Summary
- validate and encode blog post slugs before constructing hrefs/URLs
- route blog links, sitemap URLs, and RSS links through safe URL helpers
- escape RSS XML values sourced from post frontmatter/site metadata

## Validation
- devenv shell -- pnpm run typecheck
- devenv shell -- pnpm run build