### PR TITLE
Add discreet theme toggle

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,3 +1,5 @@
+import { ThemeToggle } from './theme-toggle'
+
 function ArrowIcon() {
   return (
     <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -15,6 +17,9 @@ export function Footer() {
   return (
     <footer className="mb-16">
       <ul className="font-sm mt-8 flex flex-col space-x-0 space-y-2 text-neutral-600 md:flex-row md:space-x-4 md:space-y-0 dark:text-neutral-300">
+        <li className="flex h-7 items-center">
+          <ThemeToggle />
+        </li>
         <li>
           <a
             className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { Moon, Sun } from 'lucide-react'
+import { useEffect, useState } from 'react'
+
+type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'adrianmross-theme'
+
+function getPreferredTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light'
+  }
+
+  const storedTheme = window.localStorage.getItem(STORAGE_KEY)
+
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return storedTheme
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function applyTheme(theme: Theme, animate = false) {
+  if (animate) {
+    document.documentElement.classList.add('theme-transition')
+    window.setTimeout(() => {
+      document.documentElement.classList.remove('theme-transition')
+    }, 360)
+  }
+
+  document.documentElement.classList.toggle('dark', theme === 'dark')
+  document.documentElement.style.colorScheme = theme
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>('light')
+
+  useEffect(() => {
+    const preferredTheme = getPreferredTheme()
+    setTheme(preferredTheme)
+    applyTheme(preferredTheme)
+  }, [])
+
+  function toggleTheme() {
+    const nextTheme = theme === 'dark' ? 'light' : 'dark'
+
+    setTheme(nextTheme)
+    window.localStorage.setItem(STORAGE_KEY, nextTheme)
+    applyTheme(nextTheme, true)
+  }
+
+  return (
+    <button
+      aria-label="Toggle color theme"
+      className="theme-toggle"
+      data-theme={theme}
+      onClick={toggleTheme}
+      title="Toggle color theme"
+      type="button"
+    >
+      <span className="theme-toggle__coin" aria-hidden="true">
+        <Sun className="theme-toggle__icon theme-toggle__icon--sun" aria-hidden="true" />
+        <Moon className="theme-toggle__icon theme-toggle__icon--moon" aria-hidden="true" />
+      </span>
+    </button>
+  )
+}

--- a/app/global.css
+++ b/app/global.css
@@ -1,32 +1,44 @@
 @import 'tailwindcss';
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 ::selection {
   background-color: #47a3f3;
   color: #fefefe;
 }
 
 :root {
+  color-scheme: light;
   --sh-class: #2d5e9d;
-  --sh-identifier: #354150;
-  --sh-sign: #8996a3;
+  --sh-identifier: #243141;
+  --sh-sign: #52616f;
   --sh-string: #007f7a;
-  --sh-keyword: #e02518;
-  --sh-comment: #a19595;
-  --sh-jsxliterals: #6266d1;
-  --sh-property: #e25a1c;
-  --sh-entity: #e25a1c;
+  --sh-keyword: #c81e11;
+  --sh-comment: #6f6161;
+  --sh-jsxliterals: #4f46c9;
+  --sh-property: #b45309;
+  --sh-entity: #b45309;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --sh-class: #4c97f8;
-    --sh-identifier: white;
-    --sh-keyword: #f47067;
-    --sh-string: #0fa295;
-  }
-  html {
-    color-scheme: dark;
-  }
+.dark {
+  color-scheme: dark;
+  --sh-class: #4c97f8;
+  --sh-identifier: rgb(245 245 245);
+  --sh-sign: #8996a3;
+  --sh-keyword: #f47067;
+  --sh-string: #0fa295;
+  --sh-comment: #a19595;
+  --sh-jsxliterals: #8b8ff2;
+  --sh-property: #f59e0b;
+  --sh-entity: #f59e0b;
+}
+
+html.theme-transition,
+html.theme-transition body,
+html.theme-transition main {
+  transition:
+    background-color 260ms ease,
+    color 260ms ease;
 }
 
 html {
@@ -62,20 +74,37 @@ html {
 
 .prose pre {
   @apply bg-neutral-50 dark:bg-neutral-900 rounded-lg overflow-x-auto border border-neutral-200 dark:border-neutral-900 py-2 px-3 text-sm;
+
+  background: rgb(250 250 250);
+  border-color: rgb(229 229 229);
+  color: rgb(38 38 38);
 }
 
 .prose code {
   @apply px-1 py-0.5 rounded-lg;
+
+  color: rgb(38 38 38);
 }
 
 .prose pre code {
   @apply p-0;
   border: initial;
+  color: inherit;
   line-height: 1.5;
 }
 
 .prose code span {
   @apply font-medium;
+}
+
+.dark .prose pre {
+  background: rgb(23 23 23);
+  border-color: rgb(38 38 38);
+  color: rgb(245 245 245);
+}
+
+.dark .prose code {
+  color: rgb(245 245 245);
 }
 
 .prose img {
@@ -144,6 +173,105 @@ table {
 
 .title {
   text-wrap: balance;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.72rem;
+  height: 1.72rem;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: rgb(82 82 82);
+  cursor: pointer;
+  outline: none;
+  perspective: 8rem;
+  transition:
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.theme-toggle:hover {
+  color: rgb(38 38 38);
+}
+
+.theme-toggle:active {
+  transform: translateY(1px);
+}
+
+.theme-toggle:focus-visible {
+  border-color: rgb(38 38 38);
+  box-shadow: 0 0 0 3px rgb(163 163 163 / 0.22);
+}
+
+.theme-toggle__coin {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  transform-style: preserve-3d;
+  transform-origin: 50% 50%;
+  transition:
+    transform 360ms cubic-bezier(0.2, 0.85, 0.25, 1),
+    filter 180ms ease;
+}
+
+.theme-toggle:hover .theme-toggle__coin {
+  filter: drop-shadow(0 0 0.28rem rgb(115 115 115 / 0.18));
+}
+
+.theme-toggle__icon {
+  grid-area: 1 / 1;
+  display: block;
+  width: 0.74rem;
+  height: 0.74rem;
+  stroke-width: 1.8;
+  transform-origin: 50% 50%;
+  transform: rotateY(0deg);
+}
+
+.theme-toggle__icon--moon {
+  display: none;
+  transform: rotateY(180deg) translateX(0.02rem);
+}
+
+.dark .theme-toggle__coin {
+  transform: rotateY(180deg);
+}
+
+.dark .theme-toggle__icon--sun {
+  display: none;
+}
+
+.dark .theme-toggle__icon--moon {
+  display: block;
+}
+
+.dark .theme-toggle {
+  color: rgb(212 212 212);
+}
+
+.dark .theme-toggle:hover {
+  color: rgb(245 245 245);
+}
+
+.dark .theme-toggle:focus-visible {
+  border-color: rgb(245 245 245 / 0.8);
+  box-shadow: 0 0 0 3px rgb(245 245 245 / 0.14);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-toggle,
+  .theme-toggle__coin,
+  .theme-toggle__icon {
+    transition-duration: 1ms;
+  }
 }
 
 .intro-copy p {
@@ -341,26 +469,29 @@ table {
 }
 
 .gleam-link {
-  --gleam-base: currentColor;
+  --gleam-base: rgb(38 38 38);
   --gleam-blue: #47a3f3;
   --gleam-green: #84cc16;
+  --gleam-glow: rgb(71 163 243 / 0.22);
 
   display: inline-block;
   font-weight: 500;
   text-decoration: none;
+  color: transparent;
   background-image: linear-gradient(
     110deg,
     var(--gleam-base) 0%,
-    var(--gleam-base) 35%,
-    var(--gleam-blue) 45%,
-    var(--gleam-green) 52%,
-    var(--gleam-base) 62%,
+    var(--gleam-base) 30%,
+    var(--gleam-blue) 43%,
+    var(--gleam-green) 50%,
+    var(--gleam-base) 66%,
     var(--gleam-base) 100%
   );
   background-position: 100% 50%;
-  background-size: 260% 100%;
+  background-size: 340% 100%;
   -webkit-background-clip: text;
   background-clip: text;
+  -webkit-text-fill-color: transparent;
   transition:
     background-position 700ms cubic-bezier(0.2, 0.8, 0.2, 1),
     text-shadow 180ms ease;
@@ -369,8 +500,7 @@ table {
 .gleam-link:hover,
 .gleam-link:focus-visible {
   background-position: 0% 50%;
-  color: transparent;
-  text-shadow: 0 0 14px rgb(71 163 243 / 0.22);
+  text-shadow: 0 0 14px var(--gleam-glow);
 }
 
 .github-link:focus-visible,
@@ -379,6 +509,10 @@ table {
   border-radius: 0.2rem;
   outline: 2px solid currentColor;
   outline-offset: 3px;
+}
+
+.gleam-link:focus-visible {
+  outline-color: var(--gleam-base);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -401,52 +535,51 @@ table {
   }
 }
 
-@media (prefers-color-scheme: dark) {
-  .gleam-link {
-    --gleam-base: rgb(229 229 229);
-    --gleam-blue: #7dd3fc;
-    --gleam-green: #bef264;
-  }
+.dark .gleam-link {
+  --gleam-base: rgb(229 229 229);
+  --gleam-blue: #7dd3fc;
+  --gleam-green: #bef264;
+  --gleam-glow: rgb(125 211 252 / 0.24);
+}
 
-  .github-link::after {
-    background: rgb(64 64 64 / 0.72);
-  }
+.dark .github-link::after {
+  background: rgb(64 64 64 / 0.72);
+}
 
-  .github-bubble {
-    border-color: rgb(38 38 38);
-    background: rgb(10 10 10 / 0.98);
-    box-shadow:
-      0 14px 34px rgb(0 0 0 / 0.42),
-      0 1px 0 rgb(255 255 255 / 0.05) inset;
-    color: rgb(245 245 245);
-  }
+.dark .github-bubble {
+  border-color: rgb(38 38 38);
+  background: rgb(10 10 10 / 0.98);
+  box-shadow:
+    0 14px 34px rgb(0 0 0 / 0.42),
+    0 1px 0 rgb(255 255 255 / 0.05) inset;
+  color: rgb(245 245 245);
+}
 
-  .github-bubble::after {
-    border-color: rgb(38 38 38);
-    background: rgb(10 10 10 / 0.98);
-  }
+.dark .github-bubble::after {
+  border-color: rgb(38 38 38);
+  background: rgb(10 10 10 / 0.98);
+}
 
-  .github-bubble-title {
-    color: rgb(163 163 163);
-  }
+.dark .github-bubble-title {
+  color: rgb(163 163 163);
+}
 
-  .contrib-cell {
-    background: rgb(22 27 34);
-  }
+.dark .contrib-cell {
+  background: rgb(22 27 34);
+}
 
-  .contrib-cell.level-1 {
-    background: #0e4429;
-  }
+.dark .contrib-cell.level-1 {
+  background: #0e4429;
+}
 
-  .contrib-cell.level-2 {
-    background: #006d32;
-  }
+.dark .contrib-cell.level-2 {
+  background: #006d32;
+}
 
-  .contrib-cell.level-3 {
-    background: #26a641;
-  }
+.dark .contrib-cell.level-3 {
+  background: #26a641;
+}
 
-  .contrib-cell.level-4 {
-    background: #39d353;
-  }
+.dark .contrib-cell.level-4 {
+  background: #39d353;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,6 +36,21 @@ export const metadata: Metadata = {
 
 const cx = (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' ')
 
+const themeScript = `
+(() => {
+  const storageKey = 'adrianmross-theme';
+  const storedTheme = window.localStorage.getItem(storageKey);
+  const theme = storedTheme === 'light' || storedTheme === 'dark'
+    ? storedTheme
+    : window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+  document.documentElement.style.colorScheme = theme;
+})();
+`
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html
@@ -44,6 +59,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className={cx('text-black bg-white dark:text-white dark:bg-black', GeistSans.variable, GeistMono.variable)}
     >
       <body suppressHydrationWarning className="antialiased max-w-xl mx-4 mt-8 lg:mx-auto">
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <main className="flex-auto min-w-0 mt-6 flex flex-col px-2 md:px-0">
           <Navbar />
           {children}


### PR DESCRIPTION
## Summary
- add a discreet footer theme toggle with persisted light/dark preference
- switch custom dark styles and code highlight colors to the theme class
- keep the Lehigh on-text glimmer readable across themes

## Tests
- pnpm run typecheck
- pnpm run build