### PR TITLE
Make theme text transitions consistent

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -22,7 +22,7 @@ export function Footer() {
         </li>
         <li>
           <a
-            className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"
+            className="flex items-center hover:text-neutral-800 dark:hover:text-neutral-100"
             rel="noopener noreferrer"
             target="_blank"
             href="/feed.xml"
@@ -33,7 +33,7 @@ export function Footer() {
         </li>
         <li>
           <a
-            className="flex items-center transition-all hover:text-neutral-800 dark:hover:text-neutral-100"
+            className="flex items-center hover:text-neutral-800 dark:hover:text-neutral-100"
             rel="noopener noreferrer"
             target="_blank"
             href="https://github.com/adrianmross/adrianmross.github.io"

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -26,7 +26,7 @@ export function Navbar() {
                 <Link
                   key={path}
                   href={path}
-                  className="transition-all hover:text-neutral-800 dark:hover:text-neutral-200 flex align-middle relative py-1 px-2 m-1"
+                  className="hover:text-neutral-800 dark:hover:text-neutral-200 flex align-middle relative py-1 px-2 m-1"
                 >
                   {name}
                 </Link>

--- a/app/global.css
+++ b/app/global.css
@@ -36,9 +36,7 @@
 html.theme-transition,
 html.theme-transition body,
 html.theme-transition main {
-  transition:
-    background-color 260ms ease,
-    color 260ms ease;
+  transition: background-color 260ms ease;
 }
 
 html {
@@ -60,7 +58,7 @@ html {
 }
 
 .prose a {
-  @apply underline transition-all decoration-neutral-400 dark:decoration-neutral-600 underline-offset-2 decoration-[0.1em];
+  @apply underline decoration-neutral-400 dark:decoration-neutral-600 underline-offset-2 decoration-[0.1em];
 }
 
 .prose .anchor:after {
@@ -469,7 +467,6 @@ table {
 }
 
 .gleam-link {
-  --gleam-base: rgb(38 38 38);
   --gleam-blue: #47a3f3;
   --gleam-green: #84cc16;
   --gleam-glow: rgb(71 163 243 / 0.22);
@@ -477,15 +474,15 @@ table {
   display: inline-block;
   font-weight: 500;
   text-decoration: none;
-  color: transparent;
+  color: rgb(38 38 38);
   background-image: linear-gradient(
     110deg,
-    var(--gleam-base) 0%,
-    var(--gleam-base) 30%,
+    currentColor 0%,
+    currentColor 30%,
     var(--gleam-blue) 43%,
     var(--gleam-green) 50%,
-    var(--gleam-base) 66%,
-    var(--gleam-base) 100%
+    currentColor 66%,
+    currentColor 100%
   );
   background-position: 100% 50%;
   background-size: 340% 100%;
@@ -512,7 +509,7 @@ table {
 }
 
 .gleam-link:focus-visible {
-  outline-color: var(--gleam-base);
+  outline-color: currentColor;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -536,7 +533,7 @@ table {
 }
 
 .dark .gleam-link {
-  --gleam-base: rgb(229 229 229);
+  color: rgb(229 229 229);
   --gleam-blue: #7dd3fc;
   --gleam-green: #bef264;
   --gleam-glow: rgb(125 211 252 / 0.24);


### PR DESCRIPTION
## Summary
- make theme toggles only ease background color so text changes happen uniformly
- remove transition-all from nav and footer links
- keep the Lehigh glimmer theme-aware without separate text color timing

## Tests
- pnpm run typecheck
- pnpm run build